### PR TITLE
Allow Test workflow only push to branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Test and Lint
 on:
   push:
+    branches:
 permissions:
   contents: read
 


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes
This should only allow the test workflow to trigger on push to branches, it should stop it from being triggered on tag push.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


