### PR TITLE
Add example prometheus configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           go-version: '1.19'
       - uses: actions/checkout@v3
       - name: Install tools
-        run: make install-tools
+        run: make install-ci-tools
       - name: Go Fmt
         run: diff -u <(echo -n) <(gofmt -d ./)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Install tools
-        run: make install-tools
+        run: make install-ci-tools
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.0.2
@@ -97,7 +97,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install tools
-        run: make install-tools
+        run: make install-ci-tools
 
       - name: Install Go
         uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,17 @@ export KO_DOCKER_REPO=$KO_DOCKER_REPO
 # include files with the `// +build mock` annotation
 TEST_TAGS:=-tags mock -coverprofile cover.out
 
-.PHONY: build generate docs test build-all-platforms clean install-tools licenses docker-build
+.PHONY: build generate docs test build-all-platforms clean install-tools licenses lint
 
-install-tools:
+install-ci-tools:
 	go install github.com/swaggo/swag/cmd/swag@v1.8.7
 	go install github.com/matryer/moq@v0.2.7
 	go install github.com/google/go-licenses@c781b427440f8ea100841eefdd308e660d26d121
 	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+
+install-local-tools: install-ci-tools
+	go install https://github.com/goreleaser/goreleaser@v1.17.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 build:
 	cd $(ROOT_DIR) && $(GO_BUILD) -o builds/$(BIN_NAME) .
@@ -52,6 +56,9 @@ clean:
 	cd $(ROOT_DIR) && \
 	rm -rf ./builds && \
 	rm -rf kodata
+
+lint:
+	golangci-lint run
 
 # generates the licenses used by the tool
 licenses:

--- a/cmd/options/exporter/options.go
+++ b/cmd/options/exporter/options.go
@@ -185,7 +185,7 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.IntVar(
 		&o.HostPort,
 		"web.listen-address",
-		8080,
+		9301,
 		"Port where the exporter webserver will listen on.",
 	)
 	fs.StringVar(
@@ -198,7 +198,7 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.IntVar(
 		&o.ProbePort,
 		"probe.listen-address",
-		8081,
+		9302,
 		"Port where the probe webserver will listen on.",
 	)
 	fs.StringVar(

--- a/dev/devshell.toml
+++ b/dev/devshell.toml
@@ -26,7 +26,7 @@ startup.kill.text = "alias done='pkill -f tmux'"
 startup.sessions.text = "alias sessions='tmux list-session'"
 # Profiling & Testing
 startup.heap.text = "alias heap='go tool pprof'"
-startup.testing.text = "alias test='make test && golangci-lint run && KO_DOCKER_REPO=ghcr.io/tfadeyi/auth0-exporter goreleaser check'"
+startup.testing.text = "alias test='make test && make lint && KO_DOCKER_REPO=ghcr.io/tfadeyi/auth0-exporter goreleaser check'"
 
 # Exporter
 startup.exporter.text = "tmux new -s exporter -d 'air -c $ROOT_DIR/dev/.air-exporter.toml'"

--- a/examples/prometheus.yaml
+++ b/examples/prometheus.yaml
@@ -1,0 +1,17 @@
+# my global config
+global:
+  scrape_interval: 5s # Set the scrape interval to every 5 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+
+scrape_configs:
+  - job_name: auth0_exporter
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['localhost:9301']
+    relabel_configs:
+      - source_labels: [ __address__ ]
+        target_label: __param_target
+      - source_labels: [ __param_target ]
+        target_label: instance
+      - target_label: __address__
+        replacement: localhost:9301


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

* Adds a simple example prometheus configuration file.
* Updates the default service port to `9301` and `9302`.
* Add new Makefile targets, for tool installation in different environments.

Still requires the alert manager configuration.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
Related #40
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


