### PR TITLE
Bugfix: fix log pagination request

### DIFF
--- a/cmd/options/exporter/options.go
+++ b/cmd/options/exporter/options.go
@@ -141,7 +141,7 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(
 		&o.FromFetchTime,
 		"auth0.from",
-		(time.Now().Add(-24 * time.Hour)).Format("2006-01-02"),
+		(time.Now()).Format("2006-01-02"),
 		"Point in time from were to start fetching auth0 logs. (format: YYYY-MM-DD)",
 	)
 	fs.StringVar(

--- a/pkg/client/logs/logs.go
+++ b/pkg/client/logs/logs.go
@@ -79,12 +79,12 @@ func (l *logClient) List(ctx context.Context, args ...interface{}) (interface{},
 			management.Query(fmt.Sprintf("date:[%s TO %s]", previousDay, previousDay)),
 		)
 		switch {
-		case len(logs) == 0:
-			return nil, errors.New("no checkpoint log was found")
 		case errors.Is(err, errors.QuotaLimitExceeded):
 			return nil, ErrAPIRateLimitReached
 		case err != nil:
 			return nil, err
+		case len(logs) == 0:
+			return nil, errors.New("no checkpoint log was found")
 		}
 		checkpoint = logs[0]
 	}

--- a/pkg/client/logs/logs.go
+++ b/pkg/client/logs/logs.go
@@ -66,27 +66,31 @@ func (l *logClient) List(ctx context.Context, args ...interface{}) (interface{},
 		}
 	}
 
-	i := 0
-	for {
-		var logs []*management.Log
-		var err error
-
-		if from.IsZero() {
-			logs, err = l.mgmt.List(
-				ctx,
-				management.IncludeFields("type", "log_id", "date", "client_name"),
-				management.Page(i),
-				management.PerPage(100),
-			)
-		} else {
-			logs, err = l.mgmt.List(
-				ctx,
-				management.IncludeFields("type", "log_id", "date", "client_name"),
-				management.Page(i),
-				management.PerPage(100),
-				management.Query(fmt.Sprintf("date:[%s TO *]", from.Format("2006-01-02"))),
-			)
+	// Get the last log from the list of logs for the previous day.
+	// This is used as the starting point for the fetching of the logs.
+	// This allows us to use the checkpoint pagination style
+	var checkpoint *management.Log
+	if !from.IsZero() {
+		previousDay := from.Add(-24 * time.Hour).Format("2006-01-02")
+		logs, err := l.mgmt.List(
+			ctx,
+			management.IncludeFields("type", "log_id", "date", "client_name"),
+			management.PerPage(1),
+			management.Query(fmt.Sprintf("date:[%s TO %s]", previousDay, previousDay)),
+		)
+		switch {
+		case len(logs) == 0:
+			return nil, errors.New("no checkpoint log was found")
+		case errors.Is(err, errors.QuotaLimitExceeded):
+			return nil, ErrAPIRateLimitReached
+		case err != nil:
+			return nil, err
 		}
+		checkpoint = logs[0]
+	}
+
+	for {
+		logs, err := l.fetchLogs(ctx, checkpoint)
 		switch {
 		case errors.Is(err, errors.QuotaLimitExceeded):
 			return nil, ErrAPIRateLimitReached
@@ -94,9 +98,28 @@ func (l *logClient) List(ctx context.Context, args ...interface{}) (interface{},
 			return nil, err
 		}
 		allLogs = append(allLogs, logs...)
-		if len(logs) < 100 {
+
+		if len(logs) == 0 {
 			return allLogs, nil
 		}
-		i++
+		checkpoint = logs[len(logs)-1]
 	}
+}
+
+// fetchLogs returns the list of logs given a starting checkpoint. If no checkpoint is passed it returns the list of the
+// latest logs. (Default: 100 items)
+func (l *logClient) fetchLogs(ctx context.Context, checkpoint *management.Log) ([]*management.Log, error) {
+	if checkpoint != nil {
+		return l.mgmt.List(
+			ctx,
+			management.IncludeFields("type", "log_id", "date", "client_name"),
+			management.From(checkpoint.GetLogID()),
+			management.Take(100),
+		)
+	}
+	return l.mgmt.List(
+		ctx,
+		management.IncludeFields("type", "log_id", "date", "client_name"),
+		management.Take(100),
+	)
 }

--- a/pkg/client/logs/logs_test.go
+++ b/pkg/client/logs/logs_test.go
@@ -83,7 +83,7 @@ func TestClient(t *testing.T) {
 					result = storedLogs[checkpoint:(checkpoint + take)]
 				}
 
-				checkpoint = checkpoint + take
+				checkpoint += take
 				firstCall = false
 
 				return result, nil


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

* Fix the Auth0 log client to use checkpoint pagination
* Updated unit tests.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing
- Unit test
- Local e2e testing:

Run:
```
go run main.go export --tls.disabled   --log.level "debug"   --web.listen-address "9301"   --auth0.domain "${TENANT}.eu.auth0.com"
```
Navigating to the metrics endpoint results in:

Output
```
ts=2023-08-03T21:40:25.892Z caller=log.go:168 level=info build="dev, commit unknown, built at unknown" msg="initialising exporter"
ts=2023-08-03T21:40:26.022Z caller=log.go:168 level=info port=9301 metrics-address=/metrics msg="starting exporter"
ts=2023-08-03T21:40:26.022Z caller=log.go:168 level=info msg="running exporter with insecure connection!"
ts=2023-08-03T21:40:26.022Z caller=log.go:168 level=info port=9302 endpoint=probe msg="starting metrics server"
ts=2023-08-03T21:40:31.565Z caller=log.go:168 level=info msg="handling request for the auth0 tenant metrics"
ts=2023-08-03T21:40:31.565Z caller=log.go:168 level=info msg="handling request for the auth0 tenant metrics"
ts=2023-08-03T21:40:31.881Z caller=log.go:168 level=info msg="successfully collected metrics from the auth0 tenant"
ts=2023-08-03T21:40:31.885Z caller=log.go:168 level=info requestID= remote_ip=127.0.0.1 host=localhost:9301 uri=/metrics method=GET path=/metrics route=/metrics user_agent="Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0" status=200 msg="incoming request"
```
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References
- #69 
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


