### PR TITLE
fix(ci): Allow the test/lint to run external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: Test and Lint
+
 on:
   push:
+    branches-ignore:
+      - main
+  pull_request:
     branches:
+      - "*"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

* Should allow the test/lint to run on PRs from a fork.

### 📚 References

* Related #93



