### PR TITLE
fix(pagination): fix log pagination

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 	exporteroptions "github.com/tfadeyi/auth0-simple-exporter/cmd/options/exporter"
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/exporter"
+	"github.com/tfadeyi/auth0-simple-exporter/pkg/exporter/format"
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/logging"
 )
 
@@ -25,9 +27,13 @@ func serveExporterCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			log := logging.NewPromLoggerWithOpts(opts.LogLevel)
-			from, err := time.Parse("2006-01-02", opts.FromFetchTime)
+			from, err := time.Parse(format.TimeFormat, opts.FromFetchTime)
 			if err != nil {
-				return errors.Annotate(err, "failed to parse value in --auth0.from flag")
+				opts.FromFetchTime = fmt.Sprintf("%sT%d:%d", opts.FromFetchTime, 23, 59)
+				from, err = time.Parse(format.TimeFormat, opts.FromFetchTime)
+				if err != nil {
+					return errors.Annotate(err, "could not parse time in --auth0.from, make sure the format is correct")
+				}
 			}
 
 			e := exporter.New(

--- a/cmd/options/exporter/options.go
+++ b/cmd/options/exporter/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/client"
+	"github.com/tfadeyi/auth0-simple-exporter/pkg/exporter/format"
 )
 
 type (
@@ -141,7 +142,7 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(
 		&o.FromFetchTime,
 		"auth0.from",
-		(time.Now()).Format("2006-01-02"),
+		(time.Now()).Format(format.TimeFormat),
 		"Point in time from were to start fetching auth0 logs. (format: YYYY-MM-DD)",
 	)
 	fs.StringVar(

--- a/pkg/client/logs/logs.go
+++ b/pkg/client/logs/logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/juju/errors"
+	"github.com/tfadeyi/auth0-simple-exporter/pkg/exporter/format"
 	"go.uber.org/multierr"
 )
 
@@ -126,13 +127,12 @@ func (l *logClient) findLatestCheckpoint(ctx context.Context, from time.Time, at
 	}
 
 	if !from.IsZero() {
-		previousDay := from.Add(-24 * time.Hour)
 		logs, err := l.mgmt.List(
 			ctx,
 			management.IncludeFields("type", "log_id", "date", "client_name"),
 			management.PerPage(1),
 			management.Page(0),
-			management.Query(fmt.Sprintf("date:[%s TO %s]", previousDay.Format("2006-01-02"), previousDay.Format("2006-01-02"))),
+			management.Query(fmt.Sprintf("date:[%s TO %s]", from.Format(time.DateOnly), from.Format(format.TimeFormat))),
 		)
 		if err != nil {
 			return nil, err
@@ -140,7 +140,7 @@ func (l *logClient) findLatestCheckpoint(ctx context.Context, from time.Time, at
 		if len(logs) > 0 {
 			return logs[0], nil
 		}
-		return l.findLatestCheckpoint(ctx, previousDay, attempt+1, maxAttempts)
+		return l.findLatestCheckpoint(ctx, from.Add(-24*time.Hour), attempt+1, maxAttempts)
 	}
 	return checkpoint, nil
 }

--- a/pkg/exporter/format/format.go
+++ b/pkg/exporter/format/format.go
@@ -1,0 +1,3 @@
+package format
+
+const TimeFormat = "2006-01-02T15:04"


### PR DESCRIPTION
Make the log pagination fetch from the latest log of the current day, this should avoid the exporter fetching logs from the entire day at every collection.