### PR TITLE
Fixed monotonicity, performance and behaviour in general

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Flags:
       --auth0.client-id string       Auth0 management api client-id.
       --auth0.client-secret string   Auth0 management api client-secret.
       --auth0.domain string          Auth0 tenant's domain. (i.e: <tenant_name>.eu.auth0.com).
-      --auth0.from string            Point in time from were to start fetching auth0 logs. (format: YYYY-MM-DD) (default "2023-04-02")
+      --auth0.from string            Point in time from were to start fetching auth0 logs. (format: RFC3339) (default Now)
       --auth0.token string           Auth0 management api static token. (the token can be used instead of client credentials).
   -h, --help                         help for export
       --log.level string             Exporter log level (debug, info, warn, error). (default "warn")

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -25,7 +25,7 @@ func serveExporterCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			log := logging.NewPromLoggerWithOpts(opts.LogLevel)
-			from, err := time.Parse("2006-01-02", opts.FromFetchTime)
+			from, err := time.Parse(time.RFC3339, opts.FromFetchTime)
 			if err != nil {
 				return errors.Annotate(err, "failed to parse value in --auth0.from flag")
 			}

--- a/cmd/options/exporter/options.go
+++ b/cmd/options/exporter/options.go
@@ -141,8 +141,8 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.StringVar(
 		&o.FromFetchTime,
 		"auth0.from",
-		(time.Now()).Format("2006-01-02"),
-		"Point in time from were to start fetching auth0 logs. (format: YYYY-MM-DD)",
+		(time.Now()).Format(time.RFC3339),
+		"Point in time from were to start fetching auth0 logs. (format: RFC3339)",
 	)
 	fs.StringVar(
 		&o.cfg.Domain,

--- a/pkg/client/logs/logs.go
+++ b/pkg/client/logs/logs.go
@@ -67,7 +67,7 @@ func (l *logClient) List(ctx context.Context, args ...interface{}) (interface{},
 	}
 
 	for {
-		query := fmt.Sprintf("date:[%s TO *]", from.UTC().Format(time.RFC3339))
+		query := fmt.Sprintf("date:{%s TO *]", from.UTC().Format(time.RFC3339))
 
 		logs, err := l.mgmt.List(
 			ctx,

--- a/pkg/client/logs/logs.go
+++ b/pkg/client/logs/logs.go
@@ -23,7 +23,6 @@ type (
 )
 
 var ErrAPIRateLimitReached = errors.New("client reached api rate limit")
-var errLastCheckpointMaxAttemptsReached = errors.New("max number of attempts was reached")
 
 // New returns a new instance of the log fetching client, plus possible errors
 func New(domain, clientID, clientSecret, token string) (*logClient, error) {
@@ -67,80 +66,38 @@ func (l *logClient) List(ctx context.Context, args ...interface{}) (interface{},
 		}
 	}
 
-	// Get the last log from the list of logs for the previous day.
-	// This is used as the starting point for the fetching of the logs.
-	// This allows us to use the checkpoint pagination style
-	var checkpoint *management.Log
-	var err error
-	checkpoint, err = l.findLatestCheckpoint(ctx, from, 0, 30)
-	switch {
-	case errors.Is(err, errLastCheckpointMaxAttemptsReached):
-		// do nothing
-	case errors.Is(err, errors.QuotaLimitExceeded):
-		return allLogs, ErrAPIRateLimitReached
-	case err != nil:
-		return allLogs, err
-	}
-
 	for {
-		logs, err := l.fetchLogs(ctx, checkpoint)
+		query := fmt.Sprintf("date:[%s TO *]", from.UTC().Format(time.RFC3339))
+
+		logs, err := l.mgmt.List(
+			ctx,
+			management.IncludeFields("type", "log_id", "date", "client_name"),
+			management.Query(query),
+			management.Sort("date:1"),
+			management.Take(50), // max number of items allowed by Auth0
+		)
+
 		switch {
 		case errors.Is(err, errors.QuotaLimitExceeded):
 			return allLogs, ErrAPIRateLimitReached
 		case err != nil:
 			return allLogs, err
 		}
-		allLogs = append(allLogs, logs...)
 
 		if len(logs) == 0 {
-			return allLogs, nil
+			break
+		} else if len(logs) == 50 {
+			// the last item is used as checkpoint (it will be the first
+			// of the next response)
+			from = *logs[len(logs)-1].Date
+			logs = logs[:len(logs)-1]
+
+			allLogs = append(allLogs, logs...)
+		} else {
+			allLogs = append(allLogs, logs...)
+			break
 		}
-		checkpoint = logs[len(logs)-1]
-	}
-}
-
-// fetchLogs returns the list of logs given a starting checkpoint. If no checkpoint is passed it returns the list of the
-// latest logs. (Default: 100 items)
-func (l *logClient) fetchLogs(ctx context.Context, checkpoint *management.Log) ([]*management.Log, error) {
-	if checkpoint != nil {
-		return l.mgmt.List(
-			ctx,
-			management.IncludeFields("type", "log_id", "date", "client_name"),
-			management.From(checkpoint.GetLogID()),
-			management.Take(100),
-		)
-	}
-	return l.mgmt.List(
-		ctx,
-		management.IncludeFields("type", "log_id", "date", "client_name"),
-		management.Take(100),
-	)
-}
-
-// findLatestCheckpoint recursively polls the logs api to find the latest available log to be use for the checkpoint pagination.
-// Keeps polling the auth0 api until max attempts are reached or a checkpoint log is found.
-func (l *logClient) findLatestCheckpoint(ctx context.Context, from time.Time, attempt, maxAttempts int) (*management.Log, error) {
-	var checkpoint *management.Log
-	if attempt > maxAttempts {
-		return nil, errLastCheckpointMaxAttemptsReached
 	}
 
-	if !from.IsZero() {
-		previousDay := from.Add(-24 * time.Hour)
-		logs, err := l.mgmt.List(
-			ctx,
-			management.IncludeFields("type", "log_id", "date", "client_name"),
-			management.PerPage(1),
-			management.Page(0),
-			management.Query(fmt.Sprintf("date:[%s TO %s]", previousDay.Format("2006-01-02"), previousDay.Format("2006-01-02"))),
-		)
-		if err != nil {
-			return nil, err
-		}
-		if len(logs) > 0 {
-			return logs[0], nil
-		}
-		return l.findLatestCheckpoint(ctx, previousDay, attempt+1, maxAttempts)
-	}
-	return checkpoint, nil
+	return allLogs, nil
 }

--- a/pkg/client/logs/logs_test.go
+++ b/pkg/client/logs/logs_test.go
@@ -55,36 +55,23 @@ func TestClient(t *testing.T) {
 
 	t.Run("successfully fetch all logs across multiple pages with client.List", func(t *testing.T) {
 		totalLogNumber := 220
-		take := 1
-		checkpoint := 0
-		firstCall := true
+		taken := 0
 
 		storedLogs := make([]*management.Log, totalLogNumber)
 		for i := 0; i < totalLogNumber; i++ {
 			var code = "f"
 			var logID = fmt.Sprintf("log-%d", i)
-			storedLogs[i] = &management.Log{LogID: &logID, Type: &code}
+			storedLogs[i] = &management.Log{LogID: &logID, Type: &code, Date: &time.Time{}}
 		}
 
 		c := logClient{mgmt: &logManagementMock{
 			ListFunc: func(ctx context.Context, opts ...management.RequestOption) ([]*management.Log, error) {
-				var result []*management.Log
-				if !firstCall {
-					take = 100
-				}
+				take := min(totalLogNumber-taken, 50)
+				result := storedLogs[taken : taken+take]
 
-				if checkpoint >= totalLogNumber {
-					return result, nil
-				}
-
-				if (checkpoint + take) >= totalLogNumber {
-					result = storedLogs[checkpoint:totalLogNumber]
-				} else {
-					result = storedLogs[checkpoint:(checkpoint + take)]
-				}
-
-				checkpoint += take
-				firstCall = false
+				// the -1 here is to compensate the fact that the c.List
+				// function sacrifices the last item (except on the last call)
+				taken += take - 1
 
 				return result, nil
 			},
@@ -92,50 +79,6 @@ func TestClient(t *testing.T) {
 
 		totalActualLogs, err := c.List(context.Background(), time.Now())
 		require.NoError(t, err)
-		assert.Len(t, totalActualLogs, totalLogNumber-1)
-	})
-}
-
-func TestFindLatestCheckpoint(t *testing.T) {
-	var checkpointID = "foo"
-	t.Run("successfully find latest checkpoint, 2 days before auth0.from", func(t *testing.T) {
-		from := time.Now()
-		maxAttempts := 30
-		expected := &management.Log{LogID: &checkpointID}
-		var globalCounter = 2
-
-		client := logClient{mgmt: &logManagementMock{
-			ListFunc: func(ctx context.Context, opts ...management.RequestOption) ([]*management.Log, error) {
-				var result []*management.Log
-				if globalCounter == 2 {
-					return append(result, &management.Log{LogID: &checkpointID}), nil
-				}
-				return result, nil
-			},
-		}}
-
-		checkpoint, err := client.findLatestCheckpoint(context.TODO(), from, globalCounter, maxAttempts)
-		require.NoError(t, err)
-		assert.EqualValues(t, expected.LogID, checkpoint.LogID)
-	})
-
-	t.Run("fails to find latest checkpoint, max attempt are reached", func(t *testing.T) {
-		from := time.Now()
-		maxAttempts := 10
-		var globalCounter = 12
-
-		client := logClient{mgmt: &logManagementMock{
-			ListFunc: func(ctx context.Context, opts ...management.RequestOption) ([]*management.Log, error) {
-				var result []*management.Log
-				if globalCounter == 2 {
-					return append(result, &management.Log{LogID: &checkpointID}), nil
-				}
-				return result, nil
-			},
-		}}
-
-		_, err := client.findLatestCheckpoint(context.TODO(), from, globalCounter, maxAttempts)
-		require.Error(t, err)
-		assert.ErrorIs(t, err, errLastCheckpointMaxAttemptsReached)
+		assert.Len(t, totalActualLogs, totalLogNumber)
 	})
 }

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -179,10 +179,12 @@ func (e *exporter) collect(ctx context.Context, m *metrics.Metrics) error {
 	case err != nil:
 		return errors.Annotate(err, "error fetching the users from Auth0")
 	}
+
 	tenantUsers, ok := list.([]*management.User)
 	if !ok {
 		return errors.New("auth0 client users fetch didn't return the expected list of User type")
 	}
+
 	if err := m.ProcessUsers(tenantUsers); err != nil {
 		e.logger.V(0).Error(err, err.Error())
 	}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -157,6 +157,10 @@ func (e *exporter) collect(ctx context.Context, m *metrics.Metrics) error {
 		return errors.New("Auth0 log client did not return the expected list of Log type")
 	}
 
+	if len(tenantLogEvents) > 0 {
+		e.startTime = *tenantLogEvents[len(tenantLogEvents)-1].Date
+	}
+
 	for _, event := range tenantLogEvents {
 		if err := m.Update(event); err != nil {
 			e.logger.V(0).Error(err, err.Error())

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/client"
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/client/logs"
 	"github.com/tfadeyi/auth0-simple-exporter/pkg/client/users"
-	"github.com/tfadeyi/auth0-simple-exporter/pkg/exporter/metrics"
 )
 
 func TestExporter(t *testing.T) {
@@ -170,13 +169,9 @@ func TestExporterHandler(t *testing.T) {
 		exporter := New(ctx, From(current), Client(client))
 
 		metricsServer := echo.New()
-		metricsServer.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-			return metrics.Middleware(next, []*management.Client{})
-		})
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		echoCtx := metricsServer.NewContext(req, rec)
-		echoCtx.Set(metrics.ListCtxKey, metrics.New(exporter.namespace, exporter.subsystem, []*management.Client{}))
 
 		require.NoError(t, exporter.metrics()(echoCtx))
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -196,13 +191,9 @@ func TestExporterHandler(t *testing.T) {
 		exporter := New(ctx, From(current), Client(client))
 
 		metricsServer := echo.New()
-		metricsServer.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-			return metrics.Middleware(next, []*management.Client{})
-		})
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		echoCtx := metricsServer.NewContext(req, rec)
-		echoCtx.Set(metrics.ListCtxKey, metrics.New(exporter.namespace, exporter.subsystem, []*management.Client{}))
 
 		require.NoError(t, exporter.metrics()(echoCtx))
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -219,13 +210,9 @@ func TestExporterHandler(t *testing.T) {
 		exporter := New(ctx, From(current), Client(client))
 
 		metricsServer := echo.New()
-		metricsServer.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-			return metrics.Middleware(next, []*management.Client{})
-		})
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		echoCtx := metricsServer.NewContext(req, rec)
-		echoCtx.Set(metrics.ListCtxKey, metrics.New(exporter.namespace, exporter.subsystem, []*management.Client{}))
 
 		require.Error(t, exporter.metrics()(echoCtx))
 	})

--- a/pkg/exporter/metrics/metrics.go
+++ b/pkg/exporter/metrics/metrics.go
@@ -58,7 +58,7 @@ type (
 		changePasswordRequestTotalCounter *prometheus.CounterVec
 		changePasswordRequestFailCounter  *prometheus.CounterVec
 
-		monthlyActiveUsersCounterMetric *prometheus.Counter
+		monthlyActiveUsersGaugeMetric *prometheus.Gauge
 	}
 
 	LogEventFunc func(m *Metrics, log *management.Log) error
@@ -111,7 +111,7 @@ func New(namespace, subsystem string, applications []*management.Client) *Metric
 		changePasswordRequestTotalCounter: changePasswordRequestTotalCounterMetric(namespace, subsystem, applications),
 		changePasswordRequestFailCounter:  changePasswordRequestFailCounterMetric(namespace, subsystem, applications),
 
-		monthlyActiveUsersCounterMetric: monthlyActiveUsersCounterMetric(namespace, subsystem, applications),
+		monthlyActiveUsersGaugeMetric: monthlyActiveUsersGaugeMetric(namespace, subsystem, applications),
 	}
 	return m
 }
@@ -181,7 +181,7 @@ func (m *Metrics) List() []prometheus.Collector {
 		m.changePasswordRequestTotalCounter,
 		m.changePasswordRequestFailCounter,
 
-		*m.monthlyActiveUsersCounterMetric,
+		*m.monthlyActiveUsersGaugeMetric,
 	}
 }
 

--- a/pkg/exporter/metrics/metrics.go
+++ b/pkg/exporter/metrics/metrics.go
@@ -3,14 +3,7 @@ package metrics
 import (
 	"github.com/auth0/go-auth0/management"
 	"github.com/juju/errors"
-	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
-)
-
-const (
-	namespaceCtxKey = "metrics-namespace"
-	subsystemCtxKey = "metrics-subsystem"
-	ListCtxKey      = "metrics-list"
 )
 
 var (
@@ -209,32 +202,6 @@ func increaseCounter(m *prometheus.CounterVec, labels ...string) {
 
 func initCounter(m *prometheus.CounterVec, labels ...string) {
 	m.WithLabelValues(labels...)
-}
-
-// This will push your metrics object into every request context for later use
-func Middleware(next echo.HandlerFunc, applicationClients []*management.Client) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		namespace := c.Get(namespaceCtxKey).(string)
-		subsystem := c.Get(subsystemCtxKey).(string)
-		c.Set(ListCtxKey, New(namespace, subsystem, applicationClients))
-		return next(c)
-	}
-}
-
-func NamespaceMiddleware(next echo.HandlerFunc, namespace string) echo.HandlerFunc {
-	// propagate exporter namespace and subsystem
-	return func(ctx echo.Context) error {
-		ctx.Set(namespaceCtxKey, namespace)
-		return next(ctx)
-	}
-}
-
-func SubsystemMiddleware(next echo.HandlerFunc, subsystem string) echo.HandlerFunc {
-	// propagate exporter namespace and subsystem
-	return func(ctx echo.Context) error {
-		ctx.Set(subsystemCtxKey, subsystem)
-		return next(ctx)
-	}
 }
 
 func (m *Metrics) ProcessUsers(users []*management.User) error {

--- a/pkg/exporter/metrics/monthly_active_users.go
+++ b/pkg/exporter/metrics/monthly_active_users.go
@@ -11,9 +11,9 @@ const (
 	tenantTotalMonthlyActiveUsers = "tenant_total_monthly_active_users"
 )
 
-func monthlyActiveUsersCounterMetric(namespace, subsystem string, applications []*management.Client) *prometheus.Counter {
-	m := prometheus.NewCounter(
-		prometheus.CounterOpts{
+func monthlyActiveUsersGaugeMetric(namespace, subsystem string, applications []*management.Client) *prometheus.Gauge {
+	m := prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(namespace, subsystem, tenantTotalMonthlyActiveUsers),
 			Help: "The total number of monthly active users on the tenant.",
 		})
@@ -21,13 +21,21 @@ func monthlyActiveUsersCounterMetric(namespace, subsystem string, applications [
 }
 
 func processMonthlyActiveUsers(m *Metrics, users []*management.User) error {
+	if len(users) == 0 {
+		return nil
+	}
+
 	currentTime := time.Now()
 	startTime := currentTime.AddDate(0, 0, -30)
+	count := 0.0
 
 	for _, user := range users {
 		if user.LastLogin != nil && (*user.LastLogin).After(startTime) {
-			(*m.monthlyActiveUsersCounterMetric).Inc()
+			count += 1
 		}
 	}
+
+	(*m.monthlyActiveUsersGaugeMetric).Set(count)
+
 	return nil
 }

--- a/pkg/exporter/server.go
+++ b/pkg/exporter/server.go
@@ -46,6 +46,9 @@ func (e *exporter) Export() error {
 		return errors.New("auth0 client applications fetch didn't return the expected list of applications client type")
 	}
 
+	e.metricsObject = metrics.New(e.namespace, e.subsystem, applications)
+	e.metricsRegistry.MustRegister(e.metricsObject.List()...)
+
 	server := echo.New()
 	server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return metrics.NamespaceMiddleware(next, e.namespace)

--- a/pkg/exporter/server.go
+++ b/pkg/exporter/server.go
@@ -50,15 +50,6 @@ func (e *exporter) Export() error {
 	e.metricsRegistry.MustRegister(e.metricsObject.List()...)
 
 	server := echo.New()
-	server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return metrics.NamespaceMiddleware(next, e.namespace)
-	})
-	server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return metrics.SubsystemMiddleware(next, e.subsystem)
-	})
-	server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return metrics.Middleware(next, applications)
-	})
 	server.Use(middleware.Recover())
 	server.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return logging.Middleware(next, log)


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

I suggest to read this PR commit-by-commit, to get a better understanding of how I achieved the final state.

Quick summary of my changes (I think they fix several bugs):

- 0234603: the Prometheus metrics object and registry are now **persisted** across calls. That's the first move to achieve the correct **monotonicity** of the counters. In addition, this improves the speed of each call, because the exporter is no more re-creating the objects (empty) every time
- 6bf1470: because of the previous changes, now most of the _echo_ middlewares can be safely removed, as we already have the right data from the beginning. This also improves the speed of the code. Also, fixed unit tests accordingly
- eaeb34b: the `--auth0.from` option now accepts **date+time** (in RFC3999 format) instead of just a date, and defaults to **Now** instead of midnight of the current day. This is of paramount importance to achieve the correct monotonicity because, as @excavador said, the counter metrics **should all be zero at the beginning**
- c927034: reworked the log pagination algorithm. Now it's not using the `log_id`s as checkpoints anymore, but precise date+time (converted to UTC) instead. This is useful because:
  1. in this way we don't need the `findLatestCheckpoint` function anymore. This leads to **less requests** to the Auth0 servers, less chance to exceed their **quota limits**, so a lot **less failures** during runtime. Bonus point: now the **code is a lot faster** because we're making less requests. Moreover, I've been able to remove the test cases related to `findLatestCheckpoint`, which also leads us to a **smaller codebase**
  2. later we'll be able to know where we left off from the previous call, and fetch just the latest logs instead of all the pages and pages of logs again and again
  3. also, in the context of this commit, I discovered the most subtle bug ever: (half the exporter's side and half Auth0's side): in the pagination function no sorting option was passed, and this meant that the **first call** to Auth0 (with no checkpoint specified) returned the logs in **ascending** order and the **subsequent calls** (when the checkpoint is specified) returned the logs in **descending** order, because for some reason this is the default (WTF Auth0?! :sweat_smile: ) This also explains why we had some sign-ups counted twice! Because the first time the list was walked forwards and the second time backwards. This was really mind-blowing to me
- 729eefb: now we need to be updating the `exporter.startTime` variable at every call. This is pretty simple: we have the foundations of the new correct behaviour, and we just need to stop reading the whole logs every time
- 53a8e69: at this point, we fixed all the metrics except `tenant_total_monthly_active_users`. It turns out that this last one is actually of the wrong type: it should be a `*prometheus.Gauge` instead of a `*prometheus.Counter`, because it can also decrease over time, in case the days pass without any new active user on the platform. In short: this metric, unlike the others, **shouldn't be monotonic**. So I fixed it and renamed it, fixed the users extraction function (`processMonthlyActiveUsers`) and also the unit tests accordingly
- e8f25ea: finally, a quick fix of a mistake I made: the time range in the `logClient.List` function should not be inclusive of the first event, otherwise we would count that event twice in consecutive calls

I hope I didn't forget anything :slightly_smiling_face: Please, don't hesitate to reach out to me if you have any doubts / questions

I'm also available for a call on Google Meet if you need it (d.motterlini@truvity.com)


### 🧪 Testing

All the unit tests are green on my laptop. I think everything is fine as it was before

### 📚 References

Fixes #136 

cc @excavador

