### PR TITLE
build(prerelease): Allow goreleaser to detect prereleses

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,8 +63,8 @@ kos:
       - linux/arm64
       - linux/arm
     tags:
-      - latest
       - '{{.Tag}}'
+      - '{{if not .Prerelease}}latest{{end}}'
     sbom: cyclonedx
     bare: true
     base_import_paths: true
@@ -75,6 +75,7 @@ checksum:
 
 release:
   draft: true
+  prerelease: auto
 
 changelog:
   sort: asc


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/auth0-simple-exporter/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

* This should allow goreleaser to detect if a tag is a prerelease, and only tag `latest` the images that are not prereleases.



